### PR TITLE
test: add coverage setting in pyproject.toml

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,3 +25,36 @@ dependencies = [
     "transformers==4.57.0",
     "faiss-cpu",
 ]
+
+[tool.coverage.run]
+# Specify source packages
+source = ["."]
+# Exclude test files from coverage measurement
+omit = [
+    "*/tests.py",
+    "*/tests/*",
+    "*/test_*.py",
+    "*/*tests.py",
+    ".venv/*",
+    "*/migrations/*",
+    "manage.py",
+    "config/*",
+    "*/__init__.py",
+    "*/admin.py",
+    "*/urls.py",
+    "*/apps.py",
+]
+
+[tool.coverage.report]
+# Reporting options
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "if typing.TYPE_CHECKING:",
+]
+show_missing = true
+skip_covered = false


### PR DESCRIPTION
## PR description

`pyproject.toml`에 테스트에서 제외할 파일을 추가해서, coverage가 유의미한 파일에 대한 테스트만 진행하게 합니다

## Types of changes
- [ ] New feature
- [ ] Bug fix
- [ ] Test
- [ ] Refactoring (peformance, style)
- [ ] CI/CD
- [x] Chore

## Related issues (if any)

## Further comments