### PR TITLE
fix: resolve zerodivisionerror on empty inputs

### DIFF
--- a/backend/gallery/tasks.py
+++ b/backend/gallery/tasks.py
@@ -86,6 +86,9 @@ def recommend_photo_from_photo(user: User, photos: list[uuid.UUID]):
     ALPHA = 0.5
     LIMIT = 20
 
+    if not photos:
+        return []
+
     target_set = set(photos)
 
     all_photos, _, graph = retrieve_photo_caption_graph(user)


### PR DESCRIPTION
## PR description

이미지 - 이미지 추천 함수에서 빈 리스트가 입력으로 들어왔을 때 ZeroDivisionError가 발생하는 것을 방지합니다

## Types of changes
- [ ] New feature
- [x] Bug fix
- [ ] Test
- [ ] Refactoring (peformance, style)
- [ ] CI/CD
- [ ] Chore

## Related issues (if any)

## Further comments