### PR TITLE
fix: add refresh on photo added to album

### DIFF
--- a/android/app/src/main/java/com/example/momentag/AlbumScreen.kt
+++ b/android/app/src/main/java/com/example/momentag/AlbumScreen.kt
@@ -326,7 +326,7 @@ fun AlbumScreen(
                             albumViewModel.deleteTagFromPhoto(photoId, tagIdValue)
                         },
                         onAddPhotosToAlbum = { photos ->
-                            albumViewModel.addRecommendedPhotosToTagAlbum(photos, tagId)
+                            albumViewModel.addRecommendedPhotosToTagAlbum(photos, tagId, tagName)
                         },
                     )
                 }

--- a/android/app/src/main/java/com/example/momentag/viewmodel/AlbumViewModel.kt
+++ b/android/app/src/main/java/com/example/momentag/viewmodel/AlbumViewModel.kt
@@ -305,6 +305,7 @@ class AlbumViewModel(
     fun addRecommendedPhotosToTagAlbum(
         photos: List<Photo>,
         tagId: String,
+        tagName: String,
     ) {
         viewModelScope.launch {
             _tagAddState.value = TagAddState.Loading
@@ -357,11 +358,9 @@ class AlbumViewModel(
 
             if (_tagAddState.value == TagAddState.Loading) {
                 _tagAddState.value = TagAddState.Success
-
-                _recommendLoadingState.value = RecommendLoadingState.Loading
-                kotlinx.coroutines.delay(3000L) // to prevent racing
-                loadRecommendations(tagId)
             }
+
+            loadAlbum(tagId, tagName)
         }
     }
 


### PR DESCRIPTION
## PR description

태그 앨범에서 추천 이미지를 앨범에 추가했을 때 현재 앨범의 이미지가 업데이트되지 않는 문제를 해결합니다

## Types of changes
- [ ] New feature
- [x] Bug fix
- [ ] Test
- [ ] Refactoring (peformance, style)
- [ ] CI/CD
- [ ] Chore

## Related issues (if any)

## Further comments