### PR TITLE
feat: add image detail focus mode

### DIFF
--- a/android/app/src/main/java/com/example/momentag/ImageDetailScreen.kt
+++ b/android/app/src/main/java/com/example/momentag/ImageDetailScreen.kt
@@ -610,17 +610,17 @@ fun ImageDetailScreen(
                     }
                 }
             }
-            }
-        }
-
-        // Overlay top bar on top of content
-        if (!isFocusMode) {
-            BackTopBar(
-                title = "MomenTag",
-                onBackClick = onNavigateBack,
-            )
         }
     }
+
+    // Overlay top bar on top of content
+    if (!isFocusMode) {
+        BackTopBar(
+            title = "MomenTag",
+            onBackClick = onNavigateBack,
+        )
+    }
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable


### PR DESCRIPTION
## PR description

이미지 디테일 스크린을 탭했을 때 사진 외의 정보를 숨기는 집중 모드를 구현합니다.

## Types of changes
- [x] New feature
- [ ] Bug fix
- [ ] Test
- [ ] Refactoring (peformance, style)
- [ ] CI/CD
- [ ] Chore

## Related issues (if any)

## Further comments
<img src="https://github.com/user-attachments/assets/0e38ee72-6edb-45a9-983f-f38e6f6f3f19" width=360 height=auto />
<img src="https://github.com/user-attachments/assets/07bfc8c6-d405-4f76-98b0-51872947145d" width=360 height=auto />