### PR TITLE
fix: remove image scroll in story

### DIFF
--- a/android/app/src/main/java/com/example/momentag/StoryScreen.kt
+++ b/android/app/src/main/java/com/example/momentag/StoryScreen.kt
@@ -31,9 +31,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.pager.PagerDefaults
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.KeyboardArrowUp
@@ -384,7 +382,6 @@ private fun StoryPageFullBlock(
             modifier =
                 Modifier
                     .matchParentSize()
-                    .verticalScroll(rememberScrollState())
                     .padding(horizontal = 16.dp),
         ) {
             Spacer(modifier = Modifier.height(12.dp))
@@ -799,7 +796,6 @@ private fun StoryPageFullBlockPreviewContent(
             modifier =
                 Modifier
                     .matchParentSize()
-                    .verticalScroll(rememberScrollState())
                     .padding(horizontal = 16.dp),
         ) {
             Text(


### PR DESCRIPTION
## PR description

스토리 스크린에서 세로로 긴 이미지의 스크롤을 방지합니다.

## Types of changes
- [ ] New feature
- [x] Bug fix
- [ ] Test
- [ ] Refactoring (peformance, style)
- [ ] CI/CD
- [ ] Chore

## Related issues (if any)

## Further comments