### PR TITLE
fix: stop polling on story screen disposal

### DIFF
--- a/android/app/src/main/java/com/example/momentag/StoryScreen.kt
+++ b/android/app/src/main/java/com/example/momentag/StoryScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -101,6 +102,13 @@ fun StoryTagSelectionScreen(
     LaunchedEffect(Unit) {
         if (storyState is StoryState.Idle) {
             viewModel.loadStories(10)
+        }
+    }
+
+    // Stop polling when navigating away from screen
+    DisposableEffect(Unit) {
+        onDispose {
+            viewModel.stopPolling()
         }
     }
 


### PR DESCRIPTION
## PR description

스토리 polling이 다른 화면으로 이동해도 계속 진행되는 이슈를 해결합니다.

## Types of changes
- [ ] New feature
- [x] Bug fix
- [ ] Test
- [ ] Refactoring (peformance, style)
- [ ] CI/CD
- [ ] Chore

## Related issues (if any)

## Further comments