### PR TITLE
Refact/story tag revision

### DIFF
--- a/android/app/src/main/java/com/example/momentag/ui/components/Tag.kt
+++ b/android/app/src/main/java/com/example/momentag/ui/components/Tag.kt
@@ -40,8 +40,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow


### PR DESCRIPTION
## PR description

스토리 태그 부분을 다음과 같이 바꿨습니다.
- 너무 긴 태그는 `Dimen.TagMaxTextWidth`에 맞춰서 ...으로 뒷 부분이 생략됩니다.
- 뒤가 생략된 태그를 길게 누르면 확장되어 전체 이름을 확인할 수 있습니다.

## Types of changes
- [ ] New feature
- [ ] Bug fix
- [ ] Test
- [x] Refactoring (peformance, style)
- [ ] CI/CD
- [ ] Chore

## Related issues (if any)

## Further comments