### PR TITLE
Refact/delete photo form album consistency

### DIFF
--- a/android/app/src/androidTest/java/com/example/momentag/ui/album/AlbumScreenTest.kt
+++ b/android/app/src/androidTest/java/com/example/momentag/ui/album/AlbumScreenTest.kt
@@ -561,7 +561,6 @@ class AlbumScreenTest {
         val removeTitle = composeTestRule.activity.getString(R.string.album_remove_photos_title)
         val removeMessage = composeTestRule.activity.getString(R.string.album_remove_photos_message, 1, testTagName)
         val remove = composeTestRule.activity.getString(R.string.album_remove)
-        val cancel = composeTestRule.activity.getString(R.string.action_cancel)
 
         // Enter selection mode and select a photo
         // Ensure content is loaded
@@ -581,13 +580,14 @@ class AlbumScreenTest {
                 .performClick()
             composeTestRule.waitForIdle()
 
-            // Then: Confirmation dialog is displayed
+            // Then: Confirmation dialog is displayed (ConfirmDialog style with X close button)
             composeTestRule.onNodeWithText(removeTitle).assertIsDisplayed()
             composeTestRule
                 .onNodeWithText(removeMessage)
                 .assertIsDisplayed()
             composeTestRule.onNodeWithText(remove).assertIsDisplayed().assertHasClickAction()
-            composeTestRule.onNodeWithText(cancel).assertIsDisplayed().assertHasClickAction()
+            // ConfirmDialog uses X button instead of Cancel text button
+            composeTestRule.onNodeWithContentDescription("Close").assertIsDisplayed().assertHasClickAction()
         }
     }
 

--- a/android/app/src/main/java/com/example/momentag/view/AlbumScreen.kt
+++ b/android/app/src/main/java/com/example/momentag/view/AlbumScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Share
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -88,6 +87,7 @@ import com.example.momentag.Screen
 import com.example.momentag.model.Photo
 import com.example.momentag.ui.components.AddPhotosButton
 import com.example.momentag.ui.components.CommonTopBar
+import com.example.momentag.ui.components.ConfirmDialog
 import com.example.momentag.ui.components.VerticalScrollbar
 import com.example.momentag.ui.components.WarningBanner
 import com.example.momentag.ui.theme.Animation
@@ -302,47 +302,30 @@ fun AlbumScreen(
     }
 
     if (isDeleteConfirmationDialogVisible) {
-        AlertDialog(
-            onDismissRequest = { isDeleteConfirmationDialogVisible = false },
-            title = {
-                Text(
-                    text = stringResource(R.string.album_remove_photos_title),
-                    style = MaterialTheme.typography.titleLarge,
+        ConfirmDialog(
+            title = stringResource(R.string.album_remove_photos_title),
+            message = stringResource(R.string.album_remove_photos_message, selectedTagAlbumPhotos.size, currentTagName),
+            confirmButtonText = stringResource(R.string.album_remove),
+            onConfirm = {
+                albumViewModel.deleteTagFromPhotos(
+                    photos = selectedTagAlbumPhotos,
+                    tagId = tagId,
                 )
-            },
-            text = {
-                Text(
-                    text = stringResource(R.string.album_remove_photos_message, selectedTagAlbumPhotos.size, currentTagName),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        albumViewModel.deleteTagFromPhotos(
-                            photos = selectedTagAlbumPhotos,
-                            tagId = tagId,
-                        )
-                        Toast
-                            .makeText(
-                                context,
-                                context.getString(R.string.album_photos_removed_count, selectedTagAlbumPhotos.size),
-                                Toast.LENGTH_SHORT,
-                            ).show()
+                Toast
+                    .makeText(
+                        context,
+                        context.getString(R.string.album_photos_removed_count, selectedTagAlbumPhotos.size),
+                        Toast.LENGTH_SHORT,
+                    ).show()
 
-                        isDeleteConfirmationDialogVisible = false
-                        isTagAlbumPhotoSelectionMode = false
-                        albumViewModel.resetTagAlbumPhotoSelection()
-                    },
-                ) {
-                    Text(stringResource(R.string.album_remove), color = MaterialTheme.colorScheme.error)
-                }
+                isDeleteConfirmationDialogVisible = false
+                isTagAlbumPhotoSelectionMode = false
+                albumViewModel.resetTagAlbumPhotoSelection()
             },
-            dismissButton = {
-                TextButton(onClick = { isDeleteConfirmationDialogVisible = false }) {
-                    Text(stringResource(R.string.action_cancel))
-                }
+            onDismiss = {
+                isDeleteConfirmationDialogVisible = false
             },
+            dismissible = true,
         )
     }
 


### PR DESCRIPTION
## PR description

Tag Album에서 photo를 삭제하는 것의 confirm dialog를 다른 화면의 confirm dialog와 일치시켰습니다.

관련된 test 모두 수정하였고, 통과 확인하였습니다.

<img width="908" height="96" alt="image" src="https://github.com/user-attachments/assets/260d93fd-e546-4482-a732-601ce1e27fc0" />


## Types of changes
- [ ] New feature
- [x] Bug fix
- [x] Test
- [ ] Refactoring (peformance, style)
- [ ] CI/CD
- [ ] Chore

## Related issues (if any)

## Further comments